### PR TITLE
feat: 0.2.2 Koliseo has inner Koliseo_Temp

### DIFF
--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -28,3 +28,4 @@ tests# tests folder name
 0.1.22# add KLS_DEBUG_CORE preprocessor directives to enable API call logs
 0.2.0# Reworked Koliseo_Temp API with split functions
 0.2.1# Fix build for mingw32
+0.2.2#

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -28,4 +28,4 @@ tests# tests folder name
 0.1.22# add KLS_DEBUG_CORE preprocessor directives to enable API call logs
 0.2.0# Reworked Koliseo_Temp API with split functions
 0.2.1# Fix build for mingw32
-0.2.2#
+0.2.2# Add t_kls pointer to Koliseo

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([koliseo], [0.2.1], [jgabaut@github.com])
+AC_INIT([koliseo], [0.2.2], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -48,7 +48,7 @@ fi
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.2.1"
+  VERSION="0.2.2"
 fi
 
 # Output variables to the config.h header

--- a/docs/koliseo.doxyfile
+++ b/docs/koliseo.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "koliseo"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.2.1"
+PROJECT_NUMBER         = "0.2.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -137,6 +137,7 @@ Koliseo* kls_new(ptrdiff_t size) {
 		kls->offset = sizeof(*kls);
 		kls->prev_offset = kls->offset;
 		kls->has_temp = 0;
+		kls->t_kls = NULL;
 		if (KOLISEO_AUTOSET_REGIONS == 1) {
 			#ifdef KLS_DEBUG_CORE
 			kls_log("KLS","Init of Region_List for kls.");
@@ -201,8 +202,15 @@ void* kls_pop(Koliseo* kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count) {
  * @param count The multiplicative quantity to scale data size to pop for.
  * @return A void pointer to the start of memory just popped from the referred Koliseo.
  */
-void* kls_temp_pop(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count) {
-	Koliseo* kls = t_kls.kls;
+void* kls_temp_pop(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count) {
+	if (t_kls == NULL) {
+		fprintf(stderr,"[ERROR] [%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#ifdef KLS_DEBUG_CORE
+		kls_log("ERROR","[%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#endif
+		abort();
+	}
+	Koliseo* kls = t_kls->kls;
 	if (kls == NULL) {
 		fprintf(stderr,"[ERROR] [%s()]: Referred Koliseo was NULL.\n",__func__);
 		#ifdef KLS_DEBUG_CORE
@@ -388,8 +396,15 @@ void* kls_push_zero_AR(Koliseo* kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t 
  * @param count The multiplicative quantity to scale data size to push for.
  * @return A void pointer to the start of memory just pushed to the referred Koliseo.
  */
-void* kls_temp_push_zero_AR(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count) {
-	Koliseo* kls = t_kls.kls;
+void* kls_temp_push_zero_AR(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count) {
+	if (t_kls == NULL) {
+		fprintf(stderr,"[ERROR] [%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#ifdef KLS_DEBUG_CORE
+		kls_log("ERROR","[%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#endif
+		abort();
+	}
+	Koliseo* kls = t_kls->kls;
 	if (kls == NULL) {
 		fprintf(stderr,"[ERROR] [%s()]: Referred Koliseo was NULL.\n",__func__);
 		#ifdef KLS_DEBUG_CORE
@@ -431,7 +446,7 @@ void* kls_temp_push_zero_AR(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align,
 		strcpy(reg->desc,KOLISEO_DEFAULT_REGION_DESC);
 		Region_List reglist = kls_emptyList();
 		reglist = kls_cons(reg,reglist);
-		t_kls.t_regs = kls_append(reglist, t_kls.t_regs);
+		t_kls->t_regs = kls_append(reglist, t_kls->t_regs);
 	}
 
 	char h_size[200];
@@ -518,8 +533,16 @@ void* kls_push_zero_named(Koliseo* kls, ptrdiff_t size, ptrdiff_t align, ptrdiff
  * @param count The multiplicative quantity to scale data size to push for.
  * @return A void pointer to the start of memory just pushed to the Koliseo.
  */
-void* kls_temp_push_zero_named(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, char* name, char* desc) {
-	Koliseo* kls = t_kls.kls;
+void* kls_temp_push_zero_named(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, char* name, char* desc) {
+	if (t_kls == NULL) {
+		fprintf(stderr,"[ERROR] [%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#ifdef KLS_DEBUG_CORE
+		kls_log("ERROR","[%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#endif
+		abort();
+	}
+
+	Koliseo* kls = t_kls->kls;
 	if (kls == NULL) {
 		fprintf(stderr,"[ERROR] [%s()]: Referred Koliseo was NULL.\n",__func__);
 		#ifdef KLS_DEBUG_CORE
@@ -562,7 +585,7 @@ void* kls_temp_push_zero_named(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t ali
 		strcpy(reg->desc,desc);
 		Region_List reglist = kls_emptyList();
 		reglist = kls_cons(reg,reglist);
-		t_kls.t_regs = kls_append(reglist, t_kls.t_regs);
+		t_kls->t_regs = kls_append(reglist, t_kls->t_regs);
 
 		char h_size[200];
 		kls_formatSize(size,h_size,sizeof(h_size));
@@ -651,8 +674,15 @@ void* kls_push_zero_typed(Koliseo* kls, ptrdiff_t size, ptrdiff_t align, ptrdiff
  * @param type The type index for pushed Region.
  * @return A void pointer to the start of memory just pushed to the referred Koliseo.
  */
-void* kls_temp_push_zero_typed(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, int type, char* name, char* desc) {
-	Koliseo* kls = t_kls.kls;
+void* kls_temp_push_zero_typed(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, int type, char* name, char* desc) {
+	if (t_kls == NULL) {
+		fprintf(stderr,"[ERROR] [%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#ifdef KLS_DEBUG_CORE
+		kls_log("ERROR","[%s()]: Passed Koliseo_Temp was NULL.\n",__func__);
+		#endif
+		abort();
+	}
+	Koliseo* kls = t_kls->kls;
 	if (kls == NULL) {
 		fprintf(stderr,"[ERROR] [%s()]: Referred Koliseo was NULL.\n",__func__);
 		#ifdef KLS_DEBUG_CORE
@@ -694,7 +724,7 @@ void* kls_temp_push_zero_typed(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t ali
 		strcpy(reg->desc,desc);
 		Region_List reglist = kls_emptyList();
 		reglist = kls_cons(reg,reglist);
-		t_kls.t_regs = kls_append(reglist, t_kls.t_regs);
+		t_kls->t_regs = kls_append(reglist, t_kls->t_regs);
 
 		char h_size[200];
 		kls_formatSize(size,h_size,sizeof(h_size));
@@ -1200,6 +1230,12 @@ void kls_clear(Koliseo* kls) {
  * @see kls_clear()
  */
 void kls_free(Koliseo* kls) {
+	if (kls->has_temp == 1) {
+		#ifdef KLS_DEBUG_CORE
+		kls_log("KLS","API Level { %i } -> KLS had an active Koliseo_Temp.", int_koliseo_version());
+		#endif
+		kls_temp_end(kls->t_kls);
+	}
 	kls_clear(kls);
 	kls_freeList(kls->regs);
 	free(kls);
@@ -1209,33 +1245,37 @@ void kls_free(Koliseo* kls) {
 }
 
 /**
- * Starts a new savestate for the passed Koliseo pointer, by initialising a Koliseo_temp and returning it.
+ * Starts a new savestate for the passed Koliseo pointer, by initialising its Koliseo_Temp pointer and returning it.
  * Notably, you should not use the original while using the copy.
  * @param kls The Koliseo at hand.
  * @return A Koliseo_Temp struct.
  * @see Koliseo_Temp
  */
-Koliseo_Temp kls_temp_start(Koliseo* kls) {
+Koliseo_Temp* kls_temp_start(Koliseo* kls) {
 	assert(kls->has_temp == 0); //TODO handle this more gracefully
-	Koliseo_Temp tmp;
-	tmp.kls = kls;
-	tmp.prev_offset = kls->prev_offset;
-	tmp.offset = kls->offset;
+	ptrdiff_t prev = kls->prev_offset;
+	ptrdiff_t off = kls->offset;
+
+	Koliseo_Temp* tmp = KLS_PUSH(kls,Koliseo_Temp,1);
+	tmp->kls = kls;
+	tmp->prev_offset = prev;
+	tmp->offset = off;
 	kls->has_temp = 1;
+	kls->t_kls = tmp;
 	if (KOLISEO_AUTOSET_TEMP_REGIONS == 1) {
 		#ifdef KLS_DEBUG_CORE
 		kls_log("KLS","Init of Region_List for temp kls.");
 		#endif
 		Region* temp_kls_header = (Region*) malloc(sizeof(Region));
-		temp_kls_header->begin_offset = tmp.prev_offset;
-		temp_kls_header->end_offset = tmp.offset;
+		temp_kls_header->begin_offset = tmp->prev_offset;
+		temp_kls_header->end_offset = tmp->offset;
 		temp_kls_header->type = Temp_KLS_Header;
 		strcpy(temp_kls_header->name,"Temp KLS Header");
 		strcpy(temp_kls_header->desc,"Denotes last region before starting the Koliseo_Temp.");
 		Region_List reglist = kls_emptyList();
 		reglist = kls_cons(temp_kls_header,reglist);
-		tmp.t_regs = reglist;
-		if (tmp.t_regs == NULL) {
+		tmp->t_regs = reglist;
+		if (tmp->t_regs == NULL) {
 		  fprintf(stderr,"[KLS] kls_temp_start() failed to get a Region_List.\n");
 		  abort();
 		}
@@ -1247,20 +1287,20 @@ Koliseo_Temp kls_temp_start(Koliseo* kls) {
 }
 
 /**
- * Ends a new savestate for the passed Koliseo pointer, by initialising a Koliseo_temp and returning it.
- * Notably, you should not use the original while using the copy.
- * @param kls The Koliseo at hand.
+ * Ends passed Koliseo_Temp pointer.
+ * @param tmp_kls The Koliseo_Temp at hand.
  */
-void kls_temp_end(Koliseo_Temp tmp_kls) {
-	tmp_kls.kls->prev_offset = tmp_kls.prev_offset;
-	tmp_kls.kls->offset = tmp_kls.offset;
+void kls_temp_end(Koliseo_Temp* tmp_kls) {
 	if (KOLISEO_AUTOSET_TEMP_REGIONS == 1) {
-		kls_freeList(tmp_kls.t_regs);
+		kls_freeList(tmp_kls->t_regs);
 	}
 	#ifdef KLS_DEBUG_CORE
 	kls_log("KLS","Ended Temp KLS.");
 	#endif
-	tmp_kls.kls->has_temp = 0;
+	tmp_kls->kls->has_temp = 0;
+	tmp_kls->kls->t_kls = NULL;
+	tmp_kls->kls->prev_offset = tmp_kls->prev_offset;
+	tmp_kls->kls->offset = tmp_kls->offset;
 }
 
 

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -12,7 +12,7 @@
 
 #define KLS_MAJOR 0 /**< Represents current major release.*/
 #define KLS_MINOR 2 /**< Represents current minor release.*/
-#define KLS_PATCH 1 /**< Represents current patch release.*/
+#define KLS_PATCH 2 /**< Represents current patch release.*/
 
 /**
  * Global variable for debug flag.
@@ -33,7 +33,7 @@ extern int KOLISEO_AUTOSET_TEMP_REGIONS;
 extern FILE* KOLISEO_DEBUG_FP;
 
 static const int KOLISEO_API_VERSION_INT = (KLS_MAJOR*1000000+KLS_MINOR*10000+KLS_PATCH*100); /**< Represents current version with numeric format.*/
-static const char KOLISEO_API_VERSION_STRING[] = "0.2.1"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char KOLISEO_API_VERSION_STRING[] = "0.2.2"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 const char* string_koliseo_version(void);
 
@@ -100,6 +100,8 @@ typedef struct list_region
 } region_list_item;
 typedef region_list_item *Region_List;
 
+struct Koliseo_Temp; //Forward declaration for Koliseo itself
+
 /**
  * Represents the initialised arena allocator struct.
  * @see kls_new()
@@ -115,6 +117,7 @@ typedef struct Koliseo {
 	ptrdiff_t prev_offset; /**< Previous position of memory pointer.*/
 	Region_List regs; /**< List of allocated Regions*/
 	int has_temp; /**< When == 1, a Koliseo_Temp is currently active on this Koliseo.*/
+	struct Koliseo_Temp* t_kls; /**< Points to related active Kolieo_Temp, when has_temp == 1.*/
 } Koliseo;
 
 /**
@@ -175,12 +178,12 @@ void kls_temp_showList_toWin(Koliseo_Temp* t_kls, WINDOW* win);
 
 #endif
 
-Koliseo_Temp kls_temp_start(Koliseo* kls);
-void kls_temp_end(Koliseo_Temp tmp_kls);
-void* kls_temp_push_zero_AR(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count);
-void* kls_temp_push_zero_named(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, char* name, char* desc);
-void* kls_temp_push_zero_typed(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, int type, char* name, char* desc);
-void* kls_temp_pop(Koliseo_Temp t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count);
+Koliseo_Temp* kls_temp_start(Koliseo* kls);
+void kls_temp_end(Koliseo_Temp* tmp_kls);
+void* kls_temp_push_zero_AR(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count);
+void* kls_temp_push_zero_named(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, char* name, char* desc);
+void* kls_temp_push_zero_typed(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count, int type, char* name, char* desc);
+void* kls_temp_pop(Koliseo_Temp* t_kls, ptrdiff_t size, ptrdiff_t align, ptrdiff_t count);
 void print_temp_kls_2file(FILE* fp, Koliseo_Temp* t_kls);
 void print_dbg_temp_kls(Koliseo_Temp* t_kls);
 

--- a/static/demo.c
+++ b/static/demo.c
@@ -81,12 +81,12 @@ int main(int argc, char** argv) {
 
   KLS_ECHOLIST(kls_reverse(kls->regs));
 
-  Koliseo_Temp temp_kls = kls_temp_start(kls);
+  Koliseo_Temp* temp_kls = kls_temp_start(kls);
 
   #ifndef MINGW32_BUILD
-  printf("[Started Koliseo_Temp] [pos: %li]\n",kls_get_pos(temp_kls.kls));
+  printf("[Started Koliseo_Temp] [pos: %li]\n",kls_get_pos(temp_kls->kls));
   #else
-  printf("[Started Koliseo_Temp] [pos: %lli]\n",kls_get_pos(temp_kls.kls));
+  printf("[Started Koliseo_Temp] [pos: %lli]\n",kls_get_pos(temp_kls->kls));
   #endif
 
   int minusone = -1;
@@ -127,9 +127,9 @@ int main(int argc, char** argv) {
   #endif
 
   #ifndef MINGW32_BUILD
-  printf("[Current position in Koliseo_Temp] [pos: %li]\n",temp_kls.offset);
+  printf("[Current position in Koliseo_Temp] [pos: %li]\n",temp_kls->offset);
   #else
-  printf("[Current position in Koliseo_Temp] [pos: %lli]\n",temp_kls.offset);
+  printf("[Current position in Koliseo_Temp] [pos: %lli]\n",temp_kls->offset);
   #endif
 
   print_dbg_kls(kls);
@@ -170,10 +170,10 @@ int main(int argc, char** argv) {
 	  wclear(win);
 	  wrefresh(win);
 	  kls_show_toWin(kls,win);
-	  kls_temp_show_toWin(&temp_kls,win);
+	  kls_temp_show_toWin(temp_kls,win);
 	  refresh();
 	  kls_showList_toWin(kls,win);
-	  kls_temp_showList_toWin(&temp_kls,win);
+	  kls_temp_showList_toWin(temp_kls,win);
 	  delwin(win);
 	  endwin();
   }
@@ -200,10 +200,11 @@ int main(int argc, char** argv) {
   #endif
 
   print_dbg_kls(kls);
-  print_dbg_temp_kls(&temp_kls);
+  print_dbg_temp_kls(temp_kls);
 
-  kls_temp_end(temp_kls);
-  printf("[Ended Koliseo_Temp]\n");
+  //We may forget to end the Koliseo_Temp...
+  //kls_temp_end(temp_kls);
+  //printf("[Ended Koliseo_Temp]\n");
 
   print_dbg_kls(kls);
 
@@ -211,6 +212,7 @@ int main(int argc, char** argv) {
   kls_clear(kls);
   print_dbg_kls(kls);
 
+  //This should also clean up an eventual Koliseo_Temp
   printf("[Free Koliseo]\n");
   kls_free(kls);
 


### PR DESCRIPTION
- Adds a `Koliseo_Temp` pointer inside `Koliseo`.
- `kls_temp_start()` pushes the `Koliseo_Temp` itself to the passed `Koliseo`, properly saving the offset beforehand.
- Updates all `kls_temp` functions to take a `Koliseo_Temp` pointer as argument.