### PR TITLE
fix: add build conditionals to PREDEFINED

### DIFF
--- a/docs/koliseo.doxyfile
+++ b/docs/koliseo.doxyfile
@@ -2348,7 +2348,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = KOLISEO_HAS_CURSES KOLISEO_HAS_GULP
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
- Add `KOLISEO_HAS_CURSES` and `KOLISEO_HAS_GULP` to `PREDEFINED` 
  - Generate docs for the optional build parts