### PR TITLE
feat: 0.5.1 Add KLS_DEFAULT_FREEF()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.5.1] - Unreleased
+
+### Added
+
+- Add `KLS_DEFAULT_FREEF` to pair up with `KLS_DEFAULT_ALLOCF` in order to allow custom malloc/free pairs
+
+### Changed
+
+- Dropped unused parameters from `kls_conf_init()`
+- Demo uses `kls_region.c` in debug builds
+
 ## [0.5.0] - 2025-06-08
 
 ### Changed

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,7 +20,7 @@ PACK_NAME = $(SHARED_LIB)-$(VERSION)-$(OS)-$(MACHINE)
 TEMPLATES_DIR = "./templates"
 
 # Source files
-demo_SOURCES = src/koliseo.c static/demo.c static/kls_banner.c
+demo_SOURCES = static/demo.c static/kls_banner.c
 lib_SOURCES = src/koliseo.c
 
 # Linking rule
@@ -39,9 +39,11 @@ endif
 if DEBUG_BUILD
 AM_LDFLAGS += -ggdb -O0
 AM_CFLAGS += -DKLS_DEBUG_CORE -DKLS_SETCONF_DEBUG
+demo_SOURCES += src/kls_region.c
 else
 # Linker flag to strip symbols
 AM_LDFLAGS += -s
+demo_SOURCES += src/koliseo.c
 endif
 
 if EXPER_BUILD

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([koliseo], [0.5.0], [jgabaut@github.com])
+AC_INIT([koliseo], [0.5.1], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -76,7 +76,7 @@ AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.5.0"
+  VERSION="0.5.1"
 fi
 
 # Output variables to the config.h header

--- a/src/kls_region.c
+++ b/src/kls_region.c
@@ -1426,9 +1426,8 @@ void KLS_autoregion_on_free(struct Koliseo* kls)
     } else {
         kls_rl_freeList(data_pt->regs);
     }
-    if (KLS_DEFAULT_ALLOCF == malloc) {
-        free(kls->extension_data);
-    }
+
+    KLS_DEFAULT_FREEF(kls->extension_data);
 }
 
 void KLS_autoregion_on_push(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user)

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -165,13 +165,9 @@ void KLS_ZEROCOUNT_default_handler_dbg__(Koliseo* kls, ptrdiff_t available, ptrd
  * Passes custom error handlers for errors in push calls.
  * @see KLS_Conf
  */
-KLS_Conf kls_conf_init_handled(int autoset_regions, int alloc_backend, ptrdiff_t reglist_kls_size, int autoset_temp_regions, int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath, KLS_Err_Handlers err_handlers)
+KLS_Conf kls_conf_init_handled(int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath, KLS_Err_Handlers err_handlers)
 {
     KLS_Conf res = {0};
-    (void) autoset_regions;
-    (void) alloc_backend;
-    (void) reglist_kls_size;
-    (void) autoset_temp_regions;
     res.kls_collect_stats = collect_stats;
     res.kls_verbose_lvl = verbose_lvl;
     res.kls_block_while_has_temp = block_while_has_temp;
@@ -216,10 +212,10 @@ KLS_Conf kls_conf_init_handled(int autoset_regions, int alloc_backend, ptrdiff_t
  * Used to prepare a KLS_Conf without caring about KOLISEO_HAS_REGIONS.
  * @see KLS_Conf
  */
-KLS_Conf kls_conf_init(int autoset_regions, int alloc_backend, ptrdiff_t reglist_kls_size, int autoset_temp_regions, int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath)
+KLS_Conf kls_conf_init(int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath)
 {
     KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    return kls_conf_init_handled(autoset_regions, alloc_backend, reglist_kls_size, autoset_temp_regions, collect_stats, verbose_lvl, block_while_has_temp, allow_zerocount_push, log_fp, log_filepath, err_handlers);
+    return kls_conf_init_handled(collect_stats, verbose_lvl, block_while_has_temp, allow_zerocount_push, log_fp, log_filepath, err_handlers);
 }
 
 /**

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -532,6 +532,24 @@ Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, k
 }
 
 /**
+ * Takes a ptrdiff_t size and a filepath for the trace output file.
+ * Additional arguments are for extensions.
+ * Returns a pointer to the prepared Koliseo.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
+ * @param size The size for Koliseo data field.
+ * @param output_path The filepath for log output.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf_alloc()
+ */
+Koliseo *kls_new_traced_ext(ptrdiff_t size, const char *output_path, KLS_Hooks ext_handlers, void* user)
+{
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    return kls_new_traced_alloc_handled_ext(size, output_path, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, ext_handlers, user);
+}
+
+/**
  * Takes a ptrdiff_t size, a filepath for the trace output file, an allocation function pointer and a free function pointer.
  * Returns a pointer to the prepared Koliseo.
  * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
@@ -600,6 +618,22 @@ Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func
 Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers)
 {
     return kls_new_dbg_alloc_handled_ext(size, alloc_func, free_func, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+}
+
+/**
+ * Takes a ptrdiff_t size.
+ * Additional arguments are for extensions.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
+ * @param size The size for Koliseo data field.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf()
+ */
+Koliseo *kls_new_dbg_ext(ptrdiff_t size, KLS_Hooks ext_handlers, void* user)
+{
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    return kls_new_dbg_alloc_handled_ext(size, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, ext_handlers, user);
 }
 
 /**

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -426,13 +426,14 @@ Koliseo *kls_new_alloc_dbg(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_f
 }
 
 /**
- * Takes a ptrdiff_t size, a KLS_Conf to configure the new Koliseo, and an allocation function pointer.
+ * Takes a ptrdiff_t size, a KLS_Conf to configure the new Koliseo, an allocation function pointer and a free function pointer.
  * Additional arguments are for extensions.
  * Calls kls_new_alloc() to initialise the Koliseo, then calls kls_set_conf() to update the config.
  * Returns the new Koliseo.
  * @param size The size for Koliseo data field.
  * @param conf The KLS_Conf for the new Koliseo.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
  * @see KLS_Conf
@@ -454,13 +455,14 @@ Koliseo *kls_new_conf_alloc_ext(ptrdiff_t size, KLS_Conf conf, kls_alloc_func al
 }
 
 /**
- * Takes a ptrdiff_t size, a KLS_Conf to configure the new Koliseo, and an allocation function pointer.
+ * Takes a ptrdiff_t size, a KLS_Conf to configure the new Koliseo, an allocation function pointer and a free function pointer.
  * Additional arguments are for extensions.
  * Calls kls_new_alloc() to initialise the Koliseo, then calls kls_set_conf() to update the config.
  * Returns the new Koliseo.
  * @param size The size for Koliseo data field.
  * @param conf The KLS_Conf for the new Koliseo.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
  * @see KLS_Conf
@@ -473,6 +475,21 @@ Koliseo *kls_new_conf_alloc(ptrdiff_t size, KLS_Conf conf, kls_alloc_func alloc_
     return kls_new_conf_alloc_ext(size, conf, alloc_func, free_func, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 }
 
+/**
+ * Takes a ptrdiff_t size, a filepath for the trace output file, an allocation function pointer and a free function pointer.
+ * Additional arguments are for extensions.
+ * Returns a pointer to the prepared Koliseo.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
+ * @param size The size for Koliseo data field.
+ * @param output_path The filepath for log output.
+ * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
+ * @param err_handlers The error handlers struct for errors in push calls.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf_alloc_ext()
+ */
 Koliseo *kls_new_traced_alloc_handled_ext(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user)
 {
 
@@ -496,12 +513,13 @@ Koliseo *kls_new_traced_alloc_handled_ext(ptrdiff_t size, const char *output_pat
 }
 
 /**
- * Takes a ptrdiff_t size, a filepath for the trace output file, and an allocation function pointer.
+ * Takes a ptrdiff_t size, a filepath for the trace output file, an allocation function pointer and a free function pointer.
  * Returns a pointer to the prepared Koliseo.
  * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
  * @param size The size for Koliseo data field.
  * @param output_path The filepath for log output.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @param err_handlers The error handlers struct for errors in push calls.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
@@ -514,12 +532,13 @@ Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, k
 }
 
 /**
- * Takes a ptrdiff_t size, a filepath for the trace output file, and an allocation function pointer.
+ * Takes a ptrdiff_t size, a filepath for the trace output file, an allocation function pointer and a free function pointer.
  * Returns a pointer to the prepared Koliseo.
  * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
  * @param size The size for Koliseo data field.
  * @param output_path The filepath for log output.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
  * @see KLS_Conf
@@ -531,6 +550,19 @@ Koliseo *kls_new_traced_alloc(ptrdiff_t size, const char *output_path, kls_alloc
     return kls_new_traced_alloc_handled(size, output_path, alloc_func, free_func, err_handlers);
 }
 
+/**
+ * Takes a ptrdiff_t size, an allocation function pointer and a free function pointer, and returns a pointer to the prepared Koliseo.
+ * Additional arguments are for extensions.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
+ * @param size The size for Koliseo data field.
+ * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
+ * @param err_handlers The error handlers for errors in push calls.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf_alloc_ext()
+ */
 Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user)
 {
 #ifndef KLS_DEBUG_CORE
@@ -554,10 +586,11 @@ Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func
 }
 
 /**
- * Takes a ptrdiff_t size and an allocation function pointer, and returns a pointer to the prepared Koliseo.
+ * Takes a ptrdiff_t size, an allocation function pointer and a free function pointer, and returns a pointer to the prepared Koliseo.
  * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
  * @param size The size for Koliseo data field.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @param err_handlers The error handlers for errors in push calls.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
@@ -570,10 +603,11 @@ Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kl
 }
 
 /**
- * Takes a ptrdiff_t size and an allocation function pointer, and returns a pointer to the prepared Koliseo.
+ * Takes a ptrdiff_t size, an allocation function pointer and a free function pointer, and returns a pointer to the prepared Koliseo.
  * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
  * @param size The size for Koliseo data field.
  * @param alloc_func The allocation function to use.
+ * @param free_func The free function to use.
  * @return A pointer to the initialised Koliseo struct, with wanted config.
  * @see Koliseo
  * @see KLS_Conf

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1107,10 +1107,10 @@ void *kls_push_zero_dbg(Koliseo *kls, ptrdiff_t size, ptrdiff_t align,
  */
 #ifndef KOLISEO_HAS_LOCATE
 void *kls_push_zero_ext(Koliseo *kls, ptrdiff_t size, ptrdiff_t align,
-                       ptrdiff_t count)
+                        ptrdiff_t count)
 #else
 void *kls_push_zero_ext_dbg(Koliseo *kls, ptrdiff_t size, ptrdiff_t align,
-                           ptrdiff_t count, Koliseo_Loc loc)
+                            ptrdiff_t count, Koliseo_Loc loc)
 #endif // KOLISEO_HAS_LOCATE
 {
 
@@ -1219,10 +1219,10 @@ void *kls_push_zero_ext_dbg(Koliseo *kls, ptrdiff_t size, ptrdiff_t align,
  */
 #ifndef KOLISEO_HAS_LOCATE
 void *kls_temp_push_zero_ext(Koliseo_Temp *t_kls, ptrdiff_t size,
-                            ptrdiff_t align, ptrdiff_t count)
+                             ptrdiff_t align, ptrdiff_t count)
 #else
 void *kls_temp_push_zero_ext_dbg(Koliseo_Temp *t_kls, ptrdiff_t size,
-                                ptrdiff_t align, ptrdiff_t count, Koliseo_Loc loc)
+                                 ptrdiff_t align, ptrdiff_t count, Koliseo_Loc loc)
 #endif // KOLISEO_HAS_LOCATE
 {
 

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -473,20 +473,7 @@ Koliseo *kls_new_conf_alloc(ptrdiff_t size, KLS_Conf conf, kls_alloc_func alloc_
     return kls_new_conf_alloc_ext(size, conf, alloc_func, free_func, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 }
 
-/**
- * Takes a ptrdiff_t size, a filepath for the trace output file, and an allocation function pointer.
- * Returns a pointer to the prepared Koliseo.
- * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
- * @param size The size for Koliseo data field.
- * @param output_path The filepath for log output.
- * @param alloc_func The allocation function to use.
- * @param err_handlers The error handlers struct for errors in push calls.
- * @return A pointer to the initialised Koliseo struct, with wanted config.
- * @see Koliseo
- * @see KLS_Conf
- * @see kls_new_conf_alloc()
- */
-Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers)
+Koliseo *kls_new_traced_alloc_handled_ext(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user)
 {
 
 #ifndef KLS_DEBUG_CORE
@@ -505,7 +492,25 @@ Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, k
                                    .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler_dbg__),
 #endif // KOLISEO_HAS_LOCATE
     };
-    return kls_new_conf_alloc(size, k, alloc_func, free_func);
+    return kls_new_conf_alloc_ext(size, k, alloc_func, free_func, ext_handlers, user);
+}
+
+/**
+ * Takes a ptrdiff_t size, a filepath for the trace output file, and an allocation function pointer.
+ * Returns a pointer to the prepared Koliseo.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a traced Koliseo, logging to the passed filepath.
+ * @param size The size for Koliseo data field.
+ * @param output_path The filepath for log output.
+ * @param alloc_func The allocation function to use.
+ * @param err_handlers The error handlers struct for errors in push calls.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf_alloc()
+ */
+Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers)
+{
+    return kls_new_traced_alloc_handled_ext(size, output_path, alloc_func, free_func, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 }
 
 /**
@@ -526,18 +531,7 @@ Koliseo *kls_new_traced_alloc(ptrdiff_t size, const char *output_path, kls_alloc
     return kls_new_traced_alloc_handled(size, output_path, alloc_func, free_func, err_handlers);
 }
 
-/**
- * Takes a ptrdiff_t size and an allocation function pointer, and returns a pointer to the prepared Koliseo.
- * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
- * @param size The size for Koliseo data field.
- * @param alloc_func The allocation function to use.
- * @param err_handlers The error handlers for errors in push calls.
- * @return A pointer to the initialised Koliseo struct, with wanted config.
- * @see Koliseo
- * @see KLS_Conf
- * @see kls_new_conf()
- */
-Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers)
+Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user)
 {
 #ifndef KLS_DEBUG_CORE
     fprintf(stderr,
@@ -554,9 +548,25 @@ Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kl
                                .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler_dbg__),
 #endif // KOLIEO_HAS_LOCATE
     };
-    Koliseo * kls = kls_new_conf_alloc(size, k, alloc_func, free_func);
+    Koliseo * kls = kls_new_conf_alloc_ext(size, k, alloc_func, free_func, ext_handlers, user);
     kls->conf.kls_verbose_lvl = 1;
     return kls;
+}
+
+/**
+ * Takes a ptrdiff_t size and an allocation function pointer, and returns a pointer to the prepared Koliseo.
+ * Calls kls_new_conf_alloc() to initialise the Koliseo with the proper config for a debug Koliseo (printing to stderr).
+ * @param size The size for Koliseo data field.
+ * @param alloc_func The allocation function to use.
+ * @param err_handlers The error handlers for errors in push calls.
+ * @return A pointer to the initialised Koliseo struct, with wanted config.
+ * @see Koliseo
+ * @see KLS_Conf
+ * @see kls_new_conf()
+ */
+Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers)
+{
+    return kls_new_dbg_alloc_handled_ext(size, alloc_func, free_func, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 }
 
 /**

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -77,7 +77,7 @@ typedef struct Koliseo_Loc {
 
 #define KLS_MAJOR 0 /**< Represents current major release.*/
 #define KLS_MINOR 5 /**< Represents current minor release.*/
-#define KLS_PATCH 0 /**< Represents current patch release.*/
+#define KLS_PATCH 1 /**< Represents current patch release.*/
 
 typedef void*(kls_alloc_func)(size_t); /**< Used to select an allocation function for the arena's backing memory.*/
 
@@ -95,7 +95,7 @@ static const int KOLISEO_API_VERSION_INT =
 /**
  * Defines current API version string.
  */
-static const char KOLISEO_API_VERSION_STRING[] = "0.5.0"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char KOLISEO_API_VERSION_STRING[] = "0.5.1"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 /**
  * Returns current koliseo version as a string.
@@ -211,9 +211,9 @@ typedef struct KLS_Conf {
     KLS_Err_Handlers err_handlers; /**< Used to pass custom error handlers for push calls.*/
 } KLS_Conf;
 
-KLS_Conf kls_conf_init_handled(int autoset_regions, int alloc_backend, ptrdiff_t reglist_kls_size, int autoset_temp_regions, int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath, KLS_Err_Handlers err_handlers);
+KLS_Conf kls_conf_init_handled(int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath, KLS_Err_Handlers err_handlers);
 
-KLS_Conf kls_conf_init(int autoset_regions, int alloc_backend, ptrdiff_t reglist_kls_size, int autoset_temp_regions, int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath);
+KLS_Conf kls_conf_init(int collect_stats, int verbose_lvl, int block_while_has_temp, int allow_zerocount_push, FILE* log_fp, const char* log_filepath);
 
 void kls_dbg_features(void);
 

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -424,10 +424,10 @@ void *kls_push_zero_dbg(Koliseo * kls, ptrdiff_t size, ptrdiff_t align,
 
 #ifndef KOLISEO_HAS_LOCATE
 void *kls_push_zero_ext(Koliseo * kls, ptrdiff_t size, ptrdiff_t align,
-                       ptrdiff_t count);
+                        ptrdiff_t count);
 #else
 void *kls_push_zero_ext_dbg(Koliseo * kls, ptrdiff_t size, ptrdiff_t align,
-                           ptrdiff_t count, Koliseo_Loc loc);
+                            ptrdiff_t count, Koliseo_Loc loc);
 #define kls_push_zero_ext(kls, size, align, count) kls_push_zero_ext_dbg((kls), (size), (align), (count), KLS_HERE)
 #endif // KOLISEO_HAS_LOCATE
 
@@ -506,10 +506,10 @@ void kls_temp_end(Koliseo_Temp * tmp_kls);
 
 #ifndef KOLISEO_HAS_LOCATE
 void *kls_temp_push_zero_ext(Koliseo_Temp * t_kls, ptrdiff_t size,
-                            ptrdiff_t align, ptrdiff_t count);
+                             ptrdiff_t align, ptrdiff_t count);
 #else
 void *kls_temp_push_zero_ext_dbg(Koliseo_Temp * t_kls, ptrdiff_t size,
-                                ptrdiff_t align, ptrdiff_t count, Koliseo_Loc loc);
+                                 ptrdiff_t align, ptrdiff_t count, Koliseo_Loc loc);
 #define kls_temp_push_zero_ext(t_kls, size, align, count) kls_temp_push_zero_ext_dbg((t_kls), (size), (align), (count), KLS_HERE)
 #endif // KOLISEO_HAS_LOCATE
 

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -381,11 +381,13 @@ Koliseo *kls_new_conf_alloc(ptrdiff_t size, KLS_Conf conf, kls_alloc_func alloc_
 
 Koliseo *kls_new_traced_alloc_handled_ext(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers);
+Koliseo *kls_new_traced_ext(ptrdiff_t size, const char *output_path, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_traced_alloc(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func);
 #define kls_new_traced(size, output_path) kls_new_traced_alloc((size), (output_path), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF)
 #define kls_new_traced_handled(size, output_path, err_handlers) kls_new_traced_alloc_handled((size), (output_path), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, (err_handlers))
 Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers);
+Koliseo *kls_new_dbg_ext(ptrdiff_t size, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_dbg_alloc(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func);
 #define kls_new_dbg(size) kls_new_dbg_alloc((size), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF)
 #define kls_new_dbg_handled(size, err_handlers) kls_new_dbg_alloc_handled((size), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, (err_handlers))

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -379,10 +379,12 @@ Koliseo *kls_new_conf_alloc(ptrdiff_t size, KLS_Conf conf, kls_alloc_func alloc_
 #define kls_new_conf_ext(size, conf, ext_handlers, user) kls_new_conf_alloc_ext((size), (conf), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, (ext_handlers), (user))
 #define kls_new_conf(size, conf) kls_new_conf_alloc((size), (conf), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF)
 
+Koliseo *kls_new_traced_alloc_handled_ext(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_traced_alloc_handled(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers);
 Koliseo *kls_new_traced_alloc(ptrdiff_t size, const char *output_path, kls_alloc_func alloc_func, kls_free_func free_func);
 #define kls_new_traced(size, output_path) kls_new_traced_alloc((size), (output_path), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF)
 #define kls_new_traced_handled(size, output_path, err_handlers) kls_new_traced_alloc_handled((size), (output_path), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, (err_handlers))
+Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers, KLS_Hooks ext_handlers, void* user);
 Koliseo *kls_new_dbg_alloc_handled(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func, KLS_Err_Handlers err_handlers);
 Koliseo *kls_new_dbg_alloc(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_func free_func);
 #define kls_new_dbg(size) kls_new_dbg_alloc((size), KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF)

--- a/static/demo.c
+++ b/static/demo.c
@@ -3,7 +3,11 @@
 
 #include <stdio.h>
 #include <locale.h>
+#ifndef DEBUG_BUILD
 #include "../src/koliseo.h"
+#else
+#include "../src/kls_region.h"
+#endif // DEBUG_BUILD
 #include "./kls_banner.h"
 
 void usage(char *progname)
@@ -37,13 +41,9 @@ int main(int argc, char **argv)
     printf("\n\nDemo for Koliseo, using API lvl [%i], version %s \n",
 	   int_koliseo_version(), string_koliseo_version());
 
-#ifndef KOLISEO_HAS_REGION
-    int KLS_REGLIST_ALLOC_KLS_BASIC = -1;
-#endif
-
     int block_usage_with_open_temp = 0;
     int allow_zerocount_push = 0;
-    KLS_Conf kls_config = kls_conf_init(1, KLS_REGLIST_ALLOC_KLS_BASIC, KLS_DEFAULT_SIZE, 1, 1, 1, block_usage_with_open_temp, allow_zerocount_push, NULL, "./static/debug_log.txt");
+    KLS_Conf kls_config = kls_conf_init(1, 1, block_usage_with_open_temp, allow_zerocount_push, NULL, "./static/debug_log.txt");
     printf("[Init Koliseo] [size: %i]\n", KLS_DEFAULT_SIZE);
     Koliseo *kls = kls_new_conf(KLS_DEFAULT_SIZE, kls_config);
 

--- a/tests/error/bad_count.k.stderr
+++ b/tests/error/bad_count.k.stderr
@@ -1,1 +1,1 @@
-[KLS] kls_push_zero_AR(): count [-1] was < 0.
+[KLS] kls_push_zero_ext(): count [-1] was < 0.

--- a/tests/error/bad_new_size.k.stderr
+++ b/tests/error/bad_new_size.k.stderr
@@ -1,2 +1,2 @@
-[ERROR]    at kls_new_alloc_ext():  invalid requested kls size (-1). Min accepted is: (192).
-[ERROR] [kls_push_zero_AR()]: Passed Koliseo was NULL.
+[ERROR]    at kls_new_alloc_ext():  invalid requested kls size (-1). Min accepted is: (200).
+[ERROR] [kls_push_zero_ext()]: Passed Koliseo was NULL.

--- a/tests/error/many_regions.c
+++ b/tests/error/many_regions.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions.c
+++ b/tests/error/many_regions.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions.c
+++ b/tests/error/many_regions.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions.k.stderr
+++ b/tests/error/many_regions.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
-[ERROR]    [kls_push_zero_AR()]:  Exceeding max_regions_kls_alloc_basic: {168}.
+[ERROR]    [kls_push_zero_ext()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/many_regions_named.c
+++ b/tests/error/many_regions_named.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_named.c
+++ b/tests/error/many_regions_named.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_named.c
+++ b/tests/error/many_regions_named.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_named.k.stderr
+++ b/tests/error/many_regions_named.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
 [ERROR]    [kls_push_zero_named()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/many_regions_typed.c
+++ b/tests/error/many_regions_typed.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_typed.c
+++ b/tests/error/many_regions_typed.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_typed.c
+++ b/tests/error/many_regions_typed.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     int iter=1;
     while(true) {

--- a/tests/error/many_regions_typed.k.stderr
+++ b/tests/error/many_regions_typed.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
 [ERROR]    [kls_push_zero_typed()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/many_temp_regions.c
+++ b/tests/error/many_temp_regions.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions.c
+++ b/tests/error/many_temp_regions.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions.c
+++ b/tests/error/many_temp_regions.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions.k.stderr
+++ b/tests/error/many_temp_regions.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
-[ERROR]    [kls_temp_push_zero_AR()]:  Exceeding max_regions_kls_alloc_basic: {168}.
+[ERROR]    [kls_temp_push_zero_ext()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/many_temp_regions_named.c
+++ b/tests/error/many_temp_regions_named.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_named.c
+++ b/tests/error/many_temp_regions_named.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_named.c
+++ b/tests/error/many_temp_regions_named.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_named.k.stderr
+++ b/tests/error/many_temp_regions_named.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
 [ERROR]    [kls_temp_push_zero_named()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/many_temp_regions_typed.c
+++ b/tests/error/many_temp_regions_typed.c
@@ -2,7 +2,7 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_traced_AR_KLS(KLS_DEFAULT_SIZE,"./static/debug_log.txt",KLS_DEFAULT_SIZE);
+    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_typed.c
+++ b/tests/error/many_temp_regions_typed.c
@@ -2,8 +2,7 @@
 
 int main(void) {
 
-    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
-    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    Koliseo* kls = kls_new_traced_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_typed.c
+++ b/tests/error/many_temp_regions_typed.c
@@ -2,7 +2,8 @@
 
 int main(void) {
 
-    Koliseo* kls = kls_new_alloc_ext(KLS_DEFAULT_SIZE, KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
+    KLS_Err_Handlers err_handlers = KLS_DEFAULT_ERR_HANDLERS;
+    Koliseo* kls = kls_new_traced_alloc_handled_ext(KLS_DEFAULT_SIZE, "./static/debug_log.txt", KLS_DEFAULT_ALLOCF, KLS_DEFAULT_FREEF, err_handlers, KLS_DEFAULT_HOOKS, KLS_DEFAULT_EXTENSION_DATA);
 
     Koliseo_Temp* t_kls = kls_temp_start(kls);
     int iter=1;

--- a/tests/error/many_temp_regions_typed.k.stderr
+++ b/tests/error/many_temp_regions_typed.k.stderr
@@ -1,3 +1,3 @@
-[WARN]    kls_new_traced_AR_KLS_alloc_handled(): KLS_DEBUG_CORE is not defined. No tracing allowed.
+[WARN]    kls_new_traced_alloc_handled_ext(): KLS_DEBUG_CORE is not defined. No tracing allowed.
 [WARN]    [kls_set_conf()]: KLS_DEBUG_CORE is not defined. Stats may not be collected in full.
 [ERROR]    [kls_temp_push_zero_typed()]:  Exceeding max_regions_kls_alloc_basic: {168}.

--- a/tests/error/zero_count_err.k.stderr
+++ b/tests/error/zero_count_err.k.stderr
@@ -1,1 +1,1 @@
-[KLS]  Doing a zero-count push. size [4] padding [0] available [16184].
+[KLS]  Doing a zero-count push. size [4] padding [0] available [16176].


### PR DESCRIPTION
### Added

- Add `KLS_DEFAULT_FREEF()`
- Add `_ext()` version for `kls_new_traced()` and `kls_new_dbg()`

### Changed

- Update `kls_conf_init()`
- Demo uses `kls_region` in debug builds
- Use `KLS_DEFAULT_FREEF()` in `on_free` hook
- Use `kls_new_traced_ext()` in `many_regions` tests
- Update docs