### PR TITLE
feat: 0.5.9 Split sprintf funcs into va_list and varargs, deprecate multiple extensions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: c
+
+    - name: Run aclocal
+      run: aclocal
+    - name: Run autoconf
+      run: autoconf
+    - name: Run automake --add-missing
+      run: automake --add-missing
+    - name: Run ./configure
+      run: ./configure
+    - name: Run make
+      run: make
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.5.9] - 2026-01-02
+
+### Added
+
+- Add `.github/workflows/codeql.yml`
+
+### Changed
+
+- Fix `static/region_example.c`
+- Deprecate multiple extensions support
+- Deprecate `KLS_DEFAULT_EXTENSIONS_LEN`, `KLS_MAX_EXTENSIONS`
+
 ## [0.5.8] - 2025-12-27
 
 ### Added

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([koliseo], [0.5.8], [jgabaut@github.com])
+AC_INIT([koliseo], [0.5.9], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -76,7 +76,7 @@ AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.5.8"
+  VERSION="0.5.9"
 fi
 
 # Output variables to the config.h header

--- a/docs/koliseo.doxyfile
+++ b/docs/koliseo.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = koliseo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.5.8
+PROJECT_NUMBER         = 0.5.9
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/kls_region.h
+++ b/src/kls_region.h
@@ -169,10 +169,16 @@ void KLS_autoregion_on_temp_push(struct Koliseo_Temp* t_kls, ptrdiff_t padding, 
     }
 #endif // KLS_DEFAULT_HOOKS
 
+/**
+ * DEPRECATED: Support for multiple extension will be dropped in the next release.
+ */
 #ifndef KLS_DEFAULT_EXTENSIONS_LEN
 #define KLS_DEFAULT_EXTENSIONS_LEN 1
 #endif // KLS_DEFAULT_EXTENSIONS_LEN
 
+/**
+ * DEPRECATED: Support for multiple extension will be dropped in the next release.
+ */
 #ifndef KLS_AUTOREGION_EXT_SLOT
 #define KLS_AUTOREGION_EXT_SLOT 0
 #endif // KLS_AUTOREGION_EXT_SLOT

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1444,6 +1444,25 @@ void *kls_push_zero_ext_dbg(Koliseo *kls, ptrdiff_t size, ptrdiff_t align,
     return p;
 }
 
+#ifndef KOLISEO_HAS_LOCATE
+char* kls_vsprintf(Koliseo* kls, const char* fmt, va_list args)
+#else
+char* kls_vsprintf_dbg(Koliseo* kls, Koliseo_Loc loc, const char* fmt, va_list args)
+#endif // KOLISEO_HAS_LOCATE
+{
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int len = vsnprintf(NULL, 0, fmt, args);
+#ifndef KOLISEO_HAS_LOCATE
+    char* str = KLS_PUSH_ARR(kls, char, len+1);
+#else
+    char* str = kls_push_zero_ext_dbg(kls, sizeof(char), KLS_ALIGNOF(char), len+1, loc);
+#endif // KOLISEO_HAS_LOCATE
+    vsnprintf(str, len+1, fmt, args_copy);
+    va_end(args_copy);
+    return str;
+}
+
 /**
  * Takes a Koliseo pointer, and a format cstring, plus varargs. Tries using the passed Koliseo to hold the result of standard formatting using the varargs.
  * @param kls The Koliseo at hand.
@@ -1458,16 +1477,11 @@ char* kls_sprintf_dbg(Koliseo* kls, Koliseo_Loc loc, const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    va_list args_copy;
-    va_copy(args_copy, args);
-    int len = vsnprintf(NULL, 0, fmt, args);
 #ifndef KOLISEO_HAS_LOCATE
-    char* str = KLS_PUSH_ARR(kls, char, len+1);
+    char* str = kls_vsprintf(kls, fmt, args);
 #else
-    char* str = kls_push_zero_ext_dbg(kls, sizeof(char), KLS_ALIGNOF(char), len+1, loc);
+    char* str = kls_vsprintf_dbg(kls, loc, fmt, args);
 #endif // KOLISEO_HAS_LOCATE
-    vsnprintf(str, len+1, fmt, args_copy);
-    va_end(args_copy);
     va_end(args);
     return str;
 }
@@ -1571,6 +1585,26 @@ void *kls_temp_push_zero_ext_dbg(Koliseo_Temp *t_kls, ptrdiff_t size,
     return p;
 }
 
+#ifndef KOLISEO_HAS_LOCATE
+char* kls_temp_vsprintf(Koliseo_Temp* kls_t, const char* fmt, va_list args)
+#else
+char* kls_temp_vsprintf_dbg(Koliseo_Temp* kls_t, Koliseo_Loc loc, const char* fmt, va_list args)
+#endif // KOLISEO_HAS_LOCATE
+{
+    va_list args_copy;
+    va_copy(args_copy, args);
+    int len = vsnprintf(NULL, 0, fmt, args);
+#ifndef KOLISEO_HAS_LOCATE
+    char* str = KLS_PUSH_ARR_T(kls_t, char, len+1);
+#else
+    char* str = kls_temp_push_zero_ext_dbg(kls_t, sizeof(char), KLS_ALIGNOF(char), len+1, loc);
+#endif // KOLISEO_HAS_LOCATE
+    vsnprintf(str, len+1, fmt, args_copy);
+    va_end(args_copy);
+    return str;
+}
+
+
 /**
  * Takes a Koliseo_Temp pointer, and a format cstring, plus varargs. Tries using the passed Koliseo_Temp to hold the result of standard formatting using the varargs.
  * @param kls_t The Koliseo_Temp at hand.
@@ -1585,16 +1619,11 @@ char* kls_temp_sprintf_dbg(Koliseo_Temp* kls_t, Koliseo_Loc loc, const char* fmt
 {
     va_list args;
     va_start(args, fmt);
-    va_list args_copy;
-    va_copy(args_copy, args);
-    int len = vsnprintf(NULL, 0, fmt, args);
 #ifndef KOLISEO_HAS_LOCATE
-    char* str = KLS_PUSH_ARR_T(kls_t, char, len+1);
+    char* str = kls_temp_vsprintf(kls_t, fmt, args);
 #else
-    char* str = kls_temp_push_zero_ext_dbg(kls_t, sizeof(char), KLS_ALIGNOF(char), len+1, loc);
+    char* str = kls_temp_vsprintf_dbg(kls_t, loc, fmt, args);
 #endif // KOLISEO_HAS_LOCATE
-    vsnprintf(str, len+1, fmt, args_copy);
-    va_end(args_copy);
     va_end(args);
     return str;
 }

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -308,6 +308,7 @@ extern KLS_Stats KLS_STATS_DEFAULT;
 #endif // KLS_DEBUG_CORE
 
 /**
+ * DEPRECATED: Support for multiple extension will be dropped in the next release.
  * Defines how many extensions can be handled at once.
  * @see KLS_Hooks
  * @see Koliseo
@@ -317,6 +318,7 @@ extern KLS_Stats KLS_STATS_DEFAULT;
 #endif // KLS_MAX_EXTENSIONS
 
 /**
+ * DEPRECATED: Support for multiple extension will be dropped in the next release.
  * Defines how many extensions are loaded on kls_new() variants lacking explicit set of KLS_Hooks.
  * Useful to be redefined by an extension file, together with KLS_DEFAULT_HOOKS.
  * @see KLS_DEFAULT_HOOKS

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -88,7 +88,7 @@ typedef struct Koliseo_Loc {
 
 #define KLS_MAJOR 0 /**< Represents current major release.*/
 #define KLS_MINOR 5 /**< Represents current minor release.*/
-#define KLS_PATCH 8 /**< Represents current patch release.*/
+#define KLS_PATCH 9 /**< Represents current patch release.*/
 
 typedef void*(kls_alloc_func)(size_t); /**< Used to select an allocation function for the arena's backing memory.*/
 typedef void(kls_free_func)(void*); /**< Used to select a free function for the arena's backing memory.*/
@@ -109,7 +109,7 @@ static const int KOLISEO_API_VERSION_INT =
 /**
  * Defines current API version string.
  */
-static const char KOLISEO_API_VERSION_STRING[] = "0.5.8"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char KOLISEO_API_VERSION_STRING[] = "0.5.9"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 /**
  * Returns current koliseo version as a string.

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -470,6 +470,13 @@ void *kls_push_zero_ext_dbg(Koliseo * kls, ptrdiff_t size, ptrdiff_t align,
 #endif // KOLISEO_HAS_LOCATE
 
 #ifndef KOLISEO_HAS_LOCATE
+char* kls_vsprintf(Koliseo* kls, const char* fmt, va_list args);
+#else
+char* kls_vsprintf_dbg(Koliseo* kls, Koliseo_Loc loc, const char* fmt, va_list args);
+#define kls_vsprintf(kls, fmt, args) kls_vsprintf_dbg((kls), KLS_HERE, (fmt), (args))
+#endif // KOLISEO_HAS_LOCATE
+
+#ifndef KOLISEO_HAS_LOCATE
 char* kls_sprintf(Koliseo* kls, const char* fmt, ...);
 #else
 char* kls_sprintf_dbg(Koliseo* kls, Koliseo_Loc loc, const char* fmt, ...);
@@ -589,6 +596,13 @@ void *kls_temp_push_zero_ext(Koliseo_Temp * t_kls, ptrdiff_t size,
 void *kls_temp_push_zero_ext_dbg(Koliseo_Temp * t_kls, ptrdiff_t size,
                                  ptrdiff_t align, ptrdiff_t count, Koliseo_Loc loc);
 #define kls_temp_push_zero_ext(t_kls, size, align, count) kls_temp_push_zero_ext_dbg((t_kls), (size), (align), (count), KLS_HERE)
+#endif // KOLISEO_HAS_LOCATE
+
+#ifndef KOLISEO_HAS_LOCATE
+char* kls_temp_vsprintf(Koliseo_Temp* kls_t, const char* fmt, va_list args);
+#else
+char* kls_temp_vsprintf_dbg(Koliseo_Temp* kls_t, Koliseo_Loc loc, const char* fmt, va_list args);
+#define kls_temp_vsprintf(t_kls, fmt, args) kls_temp_vsprintf_dbg((t_kls), KLS_HERE, (fmt), (args))
 #endif // KOLISEO_HAS_LOCATE
 
 #ifndef KOLISEO_HAS_LOCATE

--- a/static/region_example.c
+++ b/static/region_example.c
@@ -8,7 +8,7 @@ int main(void) {
 
     Koliseo* kls = kls_new(KLS_DEFAULT_SIZE);
 
-    printf("kls->extension_handlers.on_push_handler == {%p}\n", kls->hooks.on_push_handler);
+    printf("kls->extension_handlers.on_push_handler == {%p}\n", kls->hooks[KLS_AUTOREGION_EXT_SLOT].on_push_handler);
     printf("KLS_DEFAULT_EXTENSION_HANDLERS.on_push_handler == {%p}\n", KLS_DEFAULT_HOOKS.on_push_handler);
     int* foo = KLS_PUSH(kls, int);
 
@@ -17,7 +17,7 @@ int main(void) {
     int* bar = KLS_PUSH(kls, int);
     printf("foo: {%i}\n", *foo);
 
-    KLS_Autoregion_Extension_Data* data_pt = (KLS_Autoregion_Extension_Data*) kls->extension_data;
+    KLS_Autoregion_Extension_Data* data_pt = (KLS_Autoregion_Extension_Data*) kls->extension_data[KLS_AUTOREGION_EXT_SLOT];
 
     printf("Region list length: {%i}\n", kls_rl_length(data_pt->regs));
     kls_rl_showList(data_pt->regs);


### PR DESCRIPTION
### Added

- Add `.github/workflows/codeql.yml`

### Changed

- Fix `static/region_example.c`
- Deprecate multiple extensions support
- Deprecate `KLS_DEFAULT_EXTENSIONS_LEN`, `KLS_MAX_EXTENSIONS`