### PR TITLE
feat: 0.6.2 Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
   - Correct type for iteration indexes in `HASHMAP_remove()`
   - Account for NULL terminator for `memcpy()` in `HASHMAP_push()`
+  - Check for strictly positive `bucket_count` in `HASHMAP_push()`
 - Fix allocation size for `growable` feature
 
 ## [0.6.1] - 2026-03-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.6.2] - Unreleased
 
+### Added
+
+- Add `huge.k` test for maximum allocation size
+
 ### Changed
 
 - Fixes for `templates/hashmap.h`:
@@ -12,6 +16,7 @@
   - Check for strictly positive `bucket_count` in `HASHMAP_push()`
 - Fix allocation size for `growable` feature
 - Preprocessor guard for usercode defining only one of `KLS_DEFAULT_ALLOCF` and `KLS_DEFAULT_FREEF`
+- Refactor `kls_formatSize` to expect `size_t`
 
 ## [0.6.1] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.2] - Unreleased
+
+### Changed
+
+- Fixes for `templates/hashmap.h`:
+  - Check for `NULL` node in `HASHMAP_get()`
+  - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
+
 ## [0.6.1] - 2026-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Account for NULL terminator for `memcpy()` in `HASHMAP_push()`
   - Check for strictly positive `bucket_count` in `HASHMAP_push()`
 - Fix allocation size for `growable` feature
+- Preprocessor guard for usercode defining only one of `KLS_DEFAULT_ALLOCF` and `KLS_DEFAULT_FREEF`
 
 ## [0.6.1] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
   - Correct type for iteration indexes in `HASHMAP_remove()`
   - Account for NULL terminator for `memcpy()` in `HASHMAP_push()`
+- Fix allocation size for `growable` feature
 
 ## [0.6.1] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixes for `templates/hashmap.h`:
   - Check for `NULL` node in `HASHMAP_get()`
   - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
+  - Correct type for iteration indexes in `HASHMAP_remove()`
 
 ## [0.6.1] - 2026-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Check for `NULL` node in `HASHMAP_get()`
   - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
   - Correct type for iteration indexes in `HASHMAP_remove()`
+  - Account for NULL terminator for `memcpy()` in `HASHMAP_push()`
 
 ## [0.6.1] - 2026-03-19
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -213,6 +213,11 @@ big_size.k:
 	$(CCOMP) tests/ok/big_size.c src/koliseo.c -o tests/ok/big_size.k -DKLS_DEBUG_CORE
 	@echo -e "\n\033[1;32mDone.\e[0m"
 
+huge.k:
+	@echo -en "Building huge.k test"
+	$(CCOMP) tests/ok/huge.c src/koliseo.c -o tests/ok/huge.k -DKLS_DEBUG_CORE
+	@echo -e "\n\033[1;32mDone.\e[0m"
+
 basic_run.k:
 	@echo -en "Building basic_run.k test"
 	$(CCOMP) tests/ok/basic_run.c src/koliseo.c -o tests/ok/basic_run.k -DKLS_DEBUG_CORE
@@ -253,7 +258,7 @@ kstr_test.k:
 	$(CCOMP) tests/ok/kstr_test.c src/koliseo.c -o tests/ok/kstr_test.k -DKLS_DEBUG_CORE
 	@echo -e "\n\033[1;32mDone.\e[0m"
 
-tests: bad_new_size.k bad_count.k bad_size.k zero_count.k zero_count_err.k basic_run.k growable.k growable_temp.k oom.k basic_gulp.k kstr_gulp.k kstr_test.k big_size.k many_regions.k many_temp_regions.k many_regions_named.k many_temp_regions_named.k many_regions_typed.k many_temp_regions_typed.k ./anvil
+tests: bad_new_size.k bad_count.k bad_size.k zero_count.k zero_count_err.k basic_run.k growable.k growable_temp.k oom.k basic_gulp.k kstr_gulp.k kstr_test.k big_size.k huge.k many_regions.k many_temp_regions.k many_regions_named.k many_temp_regions_named.k many_regions_typed.k many_temp_regions_typed.k ./anvil
 
 anviltest: tests
 	@echo -en "Running anvil tests.\n"

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([koliseo], [0.6.1], [jgabaut@github.com])
+AC_INIT([koliseo], [0.6.2], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -76,7 +76,7 @@ AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.6.1"
+  VERSION="0.6.2"
 fi
 
 # Output variables to the config.h header

--- a/docs/koliseo.doxyfile
+++ b/docs/koliseo.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = koliseo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.6.1
+PROJECT_NUMBER         = 0.6.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -893,11 +893,11 @@ Koliseo *kls_new_dbg_alloc_handled_ext(ptrdiff_t size, kls_alloc_func alloc_func
     KLS_Conf k = (KLS_Conf) {
         .collect_stats = 1,.verbose_lvl = 0,
 #ifndef KOLISEO_HAS_LOCATE
-                           .err_handlers.OOM_handler = ( err_handlers.OOM_handler != NULL ? err_handlers.OOM_handler : &KLS_OOM_default_handler__),
-                           .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler__),
+        .err_handlers.OOM_handler = ( err_handlers.OOM_handler != NULL ? err_handlers.OOM_handler : &KLS_OOM_default_handler__),
+        .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler__),
 #else
-                           .err_handlers.OOM_handler = ( err_handlers.OOM_handler != NULL ? err_handlers.OOM_handler : &KLS_OOM_default_handler_dbg__),
-                           .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler_dbg__),
+        .err_handlers.OOM_handler = ( err_handlers.OOM_handler != NULL ? err_handlers.OOM_handler : &KLS_OOM_default_handler_dbg__),
+        .err_handlers.PTRDIFF_MAX_handler = ( err_handlers.PTRDIFF_MAX_handler != NULL ? err_handlers.PTRDIFF_MAX_handler : &KLS_PTRDIFF_MAX_default_handler_dbg__),
 #endif // KOLIEO_HAS_LOCATE
     };
     Koliseo * kls = kls_new_conf_alloc_ext(size, k, alloc_func, free_func, ext_handlers, user);

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1934,21 +1934,23 @@ void print_dbg_temp_kls(const Koliseo_Temp *t_kls)
  * @param outputBuffer The output buffer.
  * @param bufferSize The output buffer size.
  */
-void kls_formatSize(ptrdiff_t size, char *outputBuffer, size_t bufferSize)
+void kls_formatSize(size_t size, char *outputBuffer, size_t bufferSize)
 {
-    const char *units[] =
-    { "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
+    static const char *units[] = {
+        "bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"
+    };
+
     const int numUnits = sizeof(units) / sizeof(units[0]);
 
-    int unitIndex = 0;
-    double sizeValue = (double)size;
+    size_t unitIndex = 0;
+    long double sizeValue = (long double)size;
 
     while (sizeValue >= 1000 && unitIndex < numUnits - 1) {
         sizeValue /= 1000;
         unitIndex++;
     }
 
-    snprintf(outputBuffer, bufferSize, "%.2f %s", sizeValue, units[unitIndex]);
+    snprintf(outputBuffer, bufferSize, "%.2Lf %s", sizeValue, units[unitIndex]);
 }
 
 /**

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1237,7 +1237,7 @@ KLS_Push_Error kls__check_available_dbg(Koliseo* kls, ptrdiff_t size, ptrdiff_t 
         if (count > PTRDIFF_MAX / size) {
             return KLS_PUSH_PTRDIFF_MAX;
         } else {
-            if (current->conf.growable == 1 && kls__try_grow(current, size + count + padding)) {
+            if (current->conf.growable == 1 && kls__try_grow(current, (size * count) + padding)) {
                 return KLS_PUSH_OK;
             }
             return KLS_PUSH_OOM;

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -592,7 +592,7 @@ void kls_clear(Koliseo * kls);
 void kls_free(Koliseo * kls);
 void print_kls_2file(FILE * fp, const Koliseo * kls);
 void print_dbg_kls(const Koliseo * kls);
-void kls_formatSize(ptrdiff_t size, char *outputBuffer, size_t bufferSize);
+void kls_formatSize(size_t size, char *outputBuffer, size_t bufferSize);
 
 #ifndef KOLISEO_HAS_LOCATE
 Koliseo_Temp *kls_temp_start(Koliseo * kls);

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -402,6 +402,10 @@ Koliseo *kls_new_alloc_dbg(ptrdiff_t size, kls_alloc_func alloc_func, kls_free_f
 #define kls_new_alloc(size, alloc_func, free_func) kls_new_alloc_dbg((size), (alloc_func), (free_func), KLS_HERE)
 #endif // KOLISEO_HAS_LOCATE
 
+#if defined(KLS_DEFAULT_ALLOCF) != defined(KLS_DEFAULT_FREEF)
+#error "KLS_DEFAULT_ALLOCF and KLS_DEFAULT_FREEF must either both be defined or both be left undefined."
+#endif
+
 #ifndef KLS_DEFAULT_ALLOCF
 #define KLS_DEFAULT_ALLOCF malloc /**< Defines the default allocation function.*/
 #endif

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -86,7 +86,7 @@ typedef struct Koliseo_Loc {
 
 #define KLS_MAJOR 0 /**< Represents current major release.*/
 #define KLS_MINOR 6 /**< Represents current minor release.*/
-#define KLS_PATCH 1 /**< Represents current patch release.*/
+#define KLS_PATCH 2 /**< Represents current patch release.*/
 
 typedef void*(kls_alloc_func)(size_t); /**< Used to select an allocation function for the arena's backing memory.*/
 typedef void(kls_free_func)(void*); /**< Used to select a free function for the arena's backing memory.*/
@@ -107,7 +107,7 @@ static const int KOLISEO_API_VERSION_INT =
 /**
  * Defines current API version string.
  */
-static const char KOLISEO_API_VERSION_STRING[] = "0.6.1"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char KOLISEO_API_VERSION_STRING[] = "0.6.2"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 /**
  * Returns current koliseo version as a string.

--- a/templates/hashmap.h
+++ b/templates/hashmap.h
@@ -153,7 +153,7 @@ static uint64_t HASHMAP_fnv_1a_hash_str(const char *s, size_t len)
 }
 
 /* Murmur2 hash */
-static uint64_t HASHMAP_murmur2_hash_str(const void *key, size_t len)
+static uint64_t HASHMAP_murmur2_hash_str(const char *key, size_t len)
 {
     const uint64_t m = 0xc6a4a7935bd1e995ULL;
     const int r = 47;
@@ -253,6 +253,7 @@ HASHMAP_T *HASHMAP_get(HASHMAP_NAME *map, const char *key)
     size_t index = h % map->bucket_count;
 
     DARRAY_NAME *node = map->buckets[index];
+    if (!node) return NULL;
     for (int i = 0; i < node->count; i++) {
         if (strcmp(node->items[i].key, key) == 0) {
             return node->items[i].value;

--- a/templates/hashmap.h
+++ b/templates/hashmap.h
@@ -224,6 +224,7 @@ HASHMAP_NAME *HASHMAP_new(Koliseo* kls, size_t bucket_count)
 
 bool HASHMAP_push(HASHMAP_NAME *map, const char *key, HASHMAP_T *value)
 {
+    if (map->bucket_count <= 0) return false;
     uint64_t h = HASHMAP_hash_str(key, strlen(key));
     size_t index = h % map->bucket_count;
 

--- a/templates/hashmap.h
+++ b/templates/hashmap.h
@@ -237,7 +237,7 @@ bool HASHMAP_push(HASHMAP_NAME *map, const char *key, HASHMAP_T *value)
     }
     Koliseo* kls = node->allocator.kls;
     char* key_dup = KLS_PUSH_STR(kls, key);
-    memcpy(key_dup, key, strlen(key));
+    memcpy(key_dup, key, strlen(key)+1);
     HASHMAP_NODE_NAME new = {
         .key = key_dup,
         .value = value,

--- a/templates/hashmap.h
+++ b/templates/hashmap.h
@@ -269,9 +269,9 @@ bool HASHMAP_remove(HASHMAP_NAME *map, const char *key)
 
     DARRAY_NAME **prev = &map->buckets[index];
     DARRAY_NAME *node = *prev;
-    for (int i = 0; i < node->count; i++) {
+    for (size_t i = 0; i < node->count; i++) {
         if (strcmp(node->items[i].key, key) == 0) {
-            for (int j = i; j < node->count -1; j++) {
+            for (size_t j = i; j + 1 < node->count; j++) {
                 (*prev)->items[j] = (*prev)->items[j+1];
             }
             (*prev)->count -= 1;

--- a/tests/ok/huge.c
+++ b/tests/ok/huge.c
@@ -1,0 +1,25 @@
+// jgabaut @ github.com/jgabaut
+// SPDX-License-Identifier: GPL-3.0-only
+#include "../../src/koliseo.h"
+
+int main(void) {
+    Koliseo* k = kls_new(1024*1024*1024);
+
+    size_t huge = (size_t)PTRDIFF_MAX + 1;
+    char buf[2000] = {0};
+    kls_formatSize(PTRDIFF_MAX, buf, 2000);
+
+    printf("Biggest single allocation is {%s} bytes.\n", buf);
+
+    kls_formatSize(SIZE_MAX, buf, 2000);
+    printf("SIZE_MAX is {%s} bytes.\n", buf);
+
+    kls_push_zero_ext(
+        k,
+        (ptrdiff_t)huge,
+        1,
+        1
+    );
+    kls_free(k);
+    return 0;
+}

--- a/tests/ok/huge.k.stderr
+++ b/tests/ok/huge.k.stderr
@@ -1,0 +1,1 @@
+[KLS] kls_push_zero_ext(): size [-9223372036854775808] was < 1.

--- a/tests/ok/huge.k.stdout
+++ b/tests/ok/huge.k.stdout
@@ -1,0 +1,2 @@
+Biggest single allocation is {9.22 EB} bytes.
+SIZE_MAX is {18.45 EB} bytes.


### PR DESCRIPTION
### Added

- Add `huge.k` test for maximum allocation size

### Changed

- Fixes for `templates/hashmap.h`:
  - Check for `NULL` node in `HASHMAP_get()`
    - Closes #106 
  - Correct type mismatch in definition signature of `HASHMAP_murmur2_hash_str()`
    - Closes #108 
  - Correct type for iteration indexes in `HASHMAP_remove()`
    - Closes #107 
  - Account for NULL terminator for `memcpy()` in `HASHMAP_push()`
    - Closes #105 
  - Check for strictly positive `bucket_count` in `HASHMAP_push()`
    - Closes #104 
- Fix allocation size for `growable` feature
  - Closes #110 
- Preprocessor guard for usercode defining only one of `KLS_DEFAULT_ALLOCF` and `KLS_DEFAULT_FREEF`
  - Closes #103 
- Refactor `kls_formatSize` to expect `size_t`