### PR TITLE
feat: 0.6.4 Add hooks for repush, temp_repush calls

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/make-anviltest.yml
+++ b/.github/workflows/make-anviltest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Run sudo apt update

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: recursive
     - name: Run aclocal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [0.6.3] - Unreleased
+## [0.6.4] - Unreleased
+
+### Added
+
+- Add `on_repush`, `on_temp_repush` handlers to `KLS_Hooks`
+
+## [0.6.3] - 2026-07-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `on_repush`, `on_temp_repush` handlers to `KLS_Hooks`
+- Add `on_repush_last`, `on_temp_repush_last` handlers to `KLS_Hooks`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.6.4] - Unreleased
+## [0.6.4] - 2026-07-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `on_repush`, `on_temp_repush` handlers to `KLS_Hooks`
 
+### Changed
+
+- Fix invalid format specifier in `kls_cmp()` for `kls_pit` template
+
 ## [0.6.3] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ typedef struct KLS_Hooks {
     KLS_hook_on_new* on_new_handler; /**< Used to pass custom new handler for kls_new_alloc calls.*/
     KLS_hook_on_free* on_free_handler; /**< Used to pass custom free handler for kls_free calls.*/
     KLS_hook_on_push* on_push_handler; /**< Used to pass custom push handler for kls_push calls.*/
-    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
+    KLS_hook_on_repush_last* on_repush_last_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
     KLS_hook_on_temp_start* on_temp_start_handler; /**< Used to pass custom start handler for kls_temp_start calls.*/
     KLS_hook_on_temp_free* on_temp_free_handler; /**< Used to pass custom free handler for kls_temp_end calls.*/
     KLS_hook_on_temp_push* on_temp_push_handler; /**< Used to pass custom push handler for kls_temp_push calls.*/
-    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
+    KLS_hook_on_temp_repush_last* on_temp_repush_last_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
 } KLS_Hooks;
 ```
   For example, `src/kls_region.h` shows how to implement support for keeping track of all allocated memory regions. See the [Region section](#extra_region).

--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ typedef struct KLS_Hooks {
     KLS_hook_on_new* on_new_handler; /**< Used to pass custom new handler for kls_new_alloc calls.*/
     KLS_hook_on_free* on_free_handler; /**< Used to pass custom free handler for kls_free calls.*/
     KLS_hook_on_push* on_push_handler; /**< Used to pass custom push handler for kls_push calls.*/
+    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
     KLS_hook_on_temp_start* on_temp_start_handler; /**< Used to pass custom start handler for kls_temp_start calls.*/
     KLS_hook_on_temp_free* on_temp_free_handler; /**< Used to pass custom free handler for kls_temp_end calls.*/
     KLS_hook_on_temp_push* on_temp_push_handler; /**< Used to pass custom push handler for kls_temp_push calls.*/
+    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
 } KLS_Hooks;
 ```
   For example, `src/kls_region.h` shows how to implement support for keeping track of all allocated memory regions. See the [Region section](#extra_region).

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Define the package name and version
-AC_INIT([koliseo], [0.6.3], [jgabaut@github.com])
+AC_INIT([koliseo], [0.6.4], [jgabaut@github.com])
 
 # Verify automake version and enable foreign option
 AM_INIT_AUTOMAKE([foreign -Wall])
@@ -76,7 +76,7 @@ AM_CONDITIONAL([LINUX_BUILD], [test "$build_linux" = "yes"])
 # Set a default version number if not specified externally
 AC_ARG_VAR([VERSION], [Version number])
 if test -z "$VERSION"; then
-  VERSION="0.6.3"
+  VERSION="0.6.4"
 fi
 
 # Output variables to the config.h header

--- a/docs/koliseo.doxyfile
+++ b/docs/koliseo.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = koliseo
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.6.3
+PROJECT_NUMBER         = 0.6.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/kls_region.c
+++ b/src/kls_region.c
@@ -1245,6 +1245,34 @@ void KLS_autoregion_on_push(struct Koliseo* kls, ptrdiff_t padding, const char* 
     }
 }
 
+void KLS_autoregion_on_repush(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user)
+{
+    assert(kls != NULL);
+    if (kls->extension_data == NULL) {
+        return;
+    }
+    struct KLS_EXTENSION_AR_DEFAULT_ARGS {
+        const char* region_name;
+        size_t region_name_len;
+        const char* region_desc;
+        size_t region_desc_len;
+        int region_type;
+    };
+    KLS_Autoregion_Extension_Data *data_pt = (KLS_Autoregion_Extension_Data*) kls->extension_data;
+    KLS_Region_List l = data_pt->regs;
+    KLS_Region *reg = kls_rl_head(l);
+    if (user) {
+        struct KLS_EXTENSION_AR_DEFAULT_ARGS *ar_args = user;
+        reg->end_offset = kls->offset;
+        reg->size = reg->end_offset - reg->begin_offset;
+        reg->type = ar_args->region_type;
+    } else {
+        reg->end_offset = kls->offset;
+        reg->size = reg->end_offset - reg->begin_offset;
+        reg->type = KLS_None;
+    }
+}
+
 void KLS_autoregion_on_temp_start(struct Koliseo_Temp* t_kls)
 {
     assert(t_kls != NULL);
@@ -1370,5 +1398,32 @@ void KLS_autoregion_on_temp_push(struct Koliseo_Temp* t_kls, ptrdiff_t padding, 
         kls__temp_autoregion(caller, t_kls, padding, ar_args->region_name, strlen(ar_args->region_name), ar_args->region_desc, strlen(ar_args->region_desc), ar_args->region_type);
     } else {
         kls__temp_autoregion(caller, t_kls, padding, KOLISEO_DEFAULT_REGION_NAME, strlen(KOLISEO_DEFAULT_REGION_NAME), KOLISEO_DEFAULT_REGION_DESC, strlen(KOLISEO_DEFAULT_REGION_DESC), KLS_None);
+    }
+}
+
+void KLS_autoregion_on_temp_repush(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user)
+{
+    assert(t_kls != NULL);
+    Koliseo* kls = t_kls->kls;
+    assert(kls != NULL);
+    struct KLS_EXTENSION_AR_DEFAULT_ARGS {
+        const char* region_name;
+        size_t region_name_len;
+        const char* region_desc;
+        size_t region_desc_len;
+        int region_type;
+    };
+    KLS_Autoregion_Extension_Data *data_pt = (KLS_Autoregion_Extension_Data*) kls->extension_data;
+    KLS_Region_List l = data_pt->regs;
+    KLS_Region *reg = kls_rl_head(l);
+    if (user) {
+        struct KLS_EXTENSION_AR_DEFAULT_ARGS *ar_args = user;
+        reg->end_offset = kls->offset;
+        reg->size = reg->end_offset - reg->begin_offset;
+        reg->type = ar_args->region_type;
+    } else {
+        reg->end_offset = kls->offset;
+        reg->size = reg->end_offset - reg->begin_offset;
+        reg->type = KLS_None;
     }
 }

--- a/src/kls_region.c
+++ b/src/kls_region.c
@@ -1245,7 +1245,7 @@ void KLS_autoregion_on_push(struct Koliseo* kls, ptrdiff_t padding, const char* 
     }
 }
 
-void KLS_autoregion_on_repush(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user)
+void KLS_autoregion_on_repush_last(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user)
 {
     assert(kls != NULL);
     if (kls->extension_data == NULL) {
@@ -1401,7 +1401,7 @@ void KLS_autoregion_on_temp_push(struct Koliseo_Temp* t_kls, ptrdiff_t padding, 
     }
 }
 
-void KLS_autoregion_on_temp_repush(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user)
+void KLS_autoregion_on_temp_repush_last(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user)
 {
     assert(t_kls != NULL);
     Koliseo* kls = t_kls->kls;

--- a/src/kls_region.h
+++ b/src/kls_region.h
@@ -154,22 +154,22 @@ typedef struct KLS_Autoregion_Extension_Data {
 void KLS_autoregion_on_new(struct Koliseo* kls);
 void KLS_autoregion_on_free(struct Koliseo* kls);
 void KLS_autoregion_on_push(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user);
-void KLS_autoregion_on_repush(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user);
+void KLS_autoregion_on_repush_last(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user);
 void KLS_autoregion_on_temp_start(struct Koliseo_Temp* t_kls);
 void KLS_autoregion_on_temp_free(struct Koliseo_Temp* t_kls);
 void KLS_autoregion_on_temp_push(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user);
-void KLS_autoregion_on_temp_repush(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user);
+void KLS_autoregion_on_temp_repush_last(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user);
 
 #ifndef KLS_DEFAULT_HOOKS
 #define KLS_DEFAULT_HOOKS (KLS_Hooks) { \
         .on_new_handler = &KLS_autoregion_on_new, \
         .on_free_handler = &KLS_autoregion_on_free, \
         .on_push_handler =  &KLS_autoregion_on_push, \
-        .on_repush_handler =  &KLS_autoregion_on_repush, \
+        .on_repush_last_handler =  &KLS_autoregion_on_repush_last, \
         .on_temp_start_handler = &KLS_autoregion_on_temp_start, \
         .on_temp_free_handler = &KLS_autoregion_on_temp_free, \
         .on_temp_push_handler = &KLS_autoregion_on_temp_push, \
-        .on_temp_repush_handler = &KLS_autoregion_on_temp_repush, \
+        .on_temp_repush_last_handler = &KLS_autoregion_on_temp_repush_last, \
     }
 #endif // KLS_DEFAULT_HOOKS
 

--- a/src/kls_region.h
+++ b/src/kls_region.h
@@ -154,18 +154,22 @@ typedef struct KLS_Autoregion_Extension_Data {
 void KLS_autoregion_on_new(struct Koliseo* kls);
 void KLS_autoregion_on_free(struct Koliseo* kls);
 void KLS_autoregion_on_push(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user);
+void KLS_autoregion_on_repush(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user);
 void KLS_autoregion_on_temp_start(struct Koliseo_Temp* t_kls);
 void KLS_autoregion_on_temp_free(struct Koliseo_Temp* t_kls);
 void KLS_autoregion_on_temp_push(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user);
+void KLS_autoregion_on_temp_repush(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user);
 
 #ifndef KLS_DEFAULT_HOOKS
 #define KLS_DEFAULT_HOOKS (KLS_Hooks) { \
         .on_new_handler = &KLS_autoregion_on_new, \
         .on_free_handler = &KLS_autoregion_on_free, \
         .on_push_handler =  &KLS_autoregion_on_push, \
+        .on_repush_handler =  &KLS_autoregion_on_repush, \
         .on_temp_start_handler = &KLS_autoregion_on_temp_start, \
         .on_temp_free_handler = &KLS_autoregion_on_temp_free, \
         .on_temp_push_handler = &KLS_autoregion_on_temp_push, \
+        .on_temp_repush_handler = &KLS_autoregion_on_temp_repush, \
     }
 #endif // KLS_DEFAULT_HOOKS
 

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1784,8 +1784,8 @@ void *kls_repush_dbg(Koliseo *kls, void* old, ptrdiff_t size, ptrdiff_t align,
 
         // Restore saved prev_offset
         current->prev_offset = saved_prev_offset;
-        if (current->hooks.on_repush_handler != NULL) {
-            current->hooks.on_repush_handler(current, padding, __func__, NULL);
+        if (current->hooks.on_repush_last_handler != NULL) {
+            current->hooks.on_repush_last_handler(current, padding, __func__, NULL);
         }
     } else {
 #ifdef KLS_DEBUG_CORE
@@ -1964,8 +1964,8 @@ void *kls_temp_repush_dbg(Koliseo_Temp *t_kls, void* old, ptrdiff_t size, ptrdif
 
         // Restore saved prev_offset
         current->prev_offset = saved_prev_offset;
-        if (current->hooks.on_temp_repush_handler != NULL) {
-            current->hooks.on_temp_repush_handler(t_kls, padding, __func__, NULL);
+        if (current->hooks.on_temp_repush_last_handler != NULL) {
+            current->hooks.on_temp_repush_last_handler(t_kls, padding, __func__, NULL);
         }
     } else {
 #ifdef KLS_DEBUG_CORE

--- a/src/koliseo.c
+++ b/src/koliseo.c
@@ -1784,6 +1784,9 @@ void *kls_repush_dbg(Koliseo *kls, void* old, ptrdiff_t size, ptrdiff_t align,
 
         // Restore saved prev_offset
         current->prev_offset = saved_prev_offset;
+        if (current->hooks.on_repush_handler != NULL) {
+            current->hooks.on_repush_handler(current, padding, __func__, NULL);
+        }
     } else {
 #ifdef KLS_DEBUG_CORE
         kls_log(current, "KLS", "%s(): pushed new memory", __func__);
@@ -1961,6 +1964,9 @@ void *kls_temp_repush_dbg(Koliseo_Temp *t_kls, void* old, ptrdiff_t size, ptrdif
 
         // Restore saved prev_offset
         current->prev_offset = saved_prev_offset;
+        if (current->hooks.on_temp_repush_handler != NULL) {
+            current->hooks.on_temp_repush_handler(t_kls, padding, __func__, NULL);
+        }
     } else {
 #ifdef KLS_DEBUG_CORE
         kls_log(current, "KLS", "%s(): pushed new memory", __func__);

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -194,17 +194,17 @@ typedef void(KLS_hook_on_temp_free)(struct Koliseo_Temp* t_kls); /**< Used to pa
 
 typedef void(KLS_hook_on_temp_push)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_push().*/
 
-typedef void(KLS_hook_on_temp_repush)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_repush().*/
+typedef void(KLS_hook_on_temp_repush)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_repush() when extending the last allocation (otherwise, the on_temp_push handler fires).*/
 
 typedef struct KLS_Hooks {
     KLS_hook_on_new* on_new_handler; /**< Used to pass custom new handler for kls_new_alloc calls.*/
     KLS_hook_on_free* on_free_handler; /**< Used to pass custom free handler for kls_free calls.*/
     KLS_hook_on_push* on_push_handler; /**< Used to pass custom push handler for kls_push calls.*/
-    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls.*/
+    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
     KLS_hook_on_temp_start* on_temp_start_handler; /**< Used to pass custom start handler for kls_temp_start calls.*/
     KLS_hook_on_temp_free* on_temp_free_handler; /**< Used to pass custom free handler for kls_temp_end calls.*/
     KLS_hook_on_temp_push* on_temp_push_handler; /**< Used to pass custom push handler for kls_temp_push calls.*/
-    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls.*/
+    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
 } KLS_Hooks;
 
 /**

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -186,7 +186,7 @@ typedef void(KLS_hook_on_free)(struct Koliseo* kls); /**< Used to pass an extens
 
 typedef void(KLS_hook_on_push)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_push().*/
 
-typedef void(KLS_hook_on_repush)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_push().*/
+typedef void(KLS_hook_on_repush)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_repush() when extending the last allocation (otherwise, the on_push handler fires).*/
 
 typedef void(KLS_hook_on_temp_start)(struct Koliseo_Temp* t_kls); /**< Used to pass an extension handler for kls_temp_start().*/
 

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -86,7 +86,7 @@ typedef struct Koliseo_Loc {
 
 #define KLS_MAJOR 0 /**< Represents current major release.*/
 #define KLS_MINOR 6 /**< Represents current minor release.*/
-#define KLS_PATCH 3 /**< Represents current patch release.*/
+#define KLS_PATCH 4 /**< Represents current patch release.*/
 
 typedef void*(kls_alloc_func)(size_t); /**< Used to select an allocation function for the arena's backing memory.*/
 typedef void(kls_free_func)(void*); /**< Used to select a free function for the arena's backing memory.*/
@@ -107,7 +107,7 @@ static const int KOLISEO_API_VERSION_INT =
 /**
  * Defines current API version string.
  */
-static const char KOLISEO_API_VERSION_STRING[] = "0.6.3"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char KOLISEO_API_VERSION_STRING[] = "0.6.4"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 /**
  * Returns current koliseo version as a string.

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -186,7 +186,7 @@ typedef void(KLS_hook_on_free)(struct Koliseo* kls); /**< Used to pass an extens
 
 typedef void(KLS_hook_on_push)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_push().*/
 
-typedef void(KLS_hook_on_repush)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_repush() when extending the last allocation (otherwise, the on_push handler fires).*/
+typedef void(KLS_hook_on_repush_last)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_repush() when extending the last allocation (otherwise, the on_push handler fires).*/
 
 typedef void(KLS_hook_on_temp_start)(struct Koliseo_Temp* t_kls); /**< Used to pass an extension handler for kls_temp_start().*/
 
@@ -194,17 +194,17 @@ typedef void(KLS_hook_on_temp_free)(struct Koliseo_Temp* t_kls); /**< Used to pa
 
 typedef void(KLS_hook_on_temp_push)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_push().*/
 
-typedef void(KLS_hook_on_temp_repush)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_repush() when extending the last allocation (otherwise, the on_temp_push handler fires).*/
+typedef void(KLS_hook_on_temp_repush_last)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_repush() when extending the last allocation (otherwise, the on_temp_push handler fires).*/
 
 typedef struct KLS_Hooks {
     KLS_hook_on_new* on_new_handler; /**< Used to pass custom new handler for kls_new_alloc calls.*/
     KLS_hook_on_free* on_free_handler; /**< Used to pass custom free handler for kls_free calls.*/
     KLS_hook_on_push* on_push_handler; /**< Used to pass custom push handler for kls_push calls.*/
-    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
+    KLS_hook_on_repush_last* on_repush_last_handler; /**< Used to pass custom push handler for kls_repush calls that extend the last allocation (otherwise, the on_push handler fires).*/
     KLS_hook_on_temp_start* on_temp_start_handler; /**< Used to pass custom start handler for kls_temp_start calls.*/
     KLS_hook_on_temp_free* on_temp_free_handler; /**< Used to pass custom free handler for kls_temp_end calls.*/
     KLS_hook_on_temp_push* on_temp_push_handler; /**< Used to pass custom push handler for kls_temp_push calls.*/
-    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
+    KLS_hook_on_temp_repush_last* on_temp_repush_last_handler; /**< Used to pass custom push handler for kls_temp_repush calls that extend the last allocation (otherwise, the on_temp_push handler fires).*/
 } KLS_Hooks;
 
 /**

--- a/src/koliseo.h
+++ b/src/koliseo.h
@@ -186,19 +186,25 @@ typedef void(KLS_hook_on_free)(struct Koliseo* kls); /**< Used to pass an extens
 
 typedef void(KLS_hook_on_push)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_push().*/
 
+typedef void(KLS_hook_on_repush)(struct Koliseo* kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_push().*/
+
 typedef void(KLS_hook_on_temp_start)(struct Koliseo_Temp* t_kls); /**< Used to pass an extension handler for kls_temp_start().*/
 
 typedef void(KLS_hook_on_temp_free)(struct Koliseo_Temp* t_kls); /**< Used to pass an extension handler for kls_temp_end().*/
 
 typedef void(KLS_hook_on_temp_push)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_push().*/
 
+typedef void(KLS_hook_on_temp_repush)(struct Koliseo_Temp* t_kls, ptrdiff_t padding, const char* caller, void* user); /**< Used to pass an extension handler for kls_temp_repush().*/
+
 typedef struct KLS_Hooks {
     KLS_hook_on_new* on_new_handler; /**< Used to pass custom new handler for kls_new_alloc calls.*/
     KLS_hook_on_free* on_free_handler; /**< Used to pass custom free handler for kls_free calls.*/
     KLS_hook_on_push* on_push_handler; /**< Used to pass custom push handler for kls_push calls.*/
+    KLS_hook_on_repush* on_repush_handler; /**< Used to pass custom push handler for kls_repush calls.*/
     KLS_hook_on_temp_start* on_temp_start_handler; /**< Used to pass custom start handler for kls_temp_start calls.*/
     KLS_hook_on_temp_free* on_temp_free_handler; /**< Used to pass custom free handler for kls_temp_end calls.*/
     KLS_hook_on_temp_push* on_temp_push_handler; /**< Used to pass custom push handler for kls_temp_push calls.*/
+    KLS_hook_on_temp_repush* on_temp_repush_handler; /**< Used to pass custom push handler for kls_temp_repush calls.*/
 } KLS_Hooks;
 
 /**

--- a/static/region_example.c
+++ b/static/region_example.c
@@ -22,6 +22,12 @@ int main(void) {
     printf("Region list length: {%i}\n", kls_rl_length(data_pt->regs));
     kls_rl_showList(data_pt->regs);
 
+    bar = KLS_REPUSH(kls, bar, int, 1, 4);
+
+    printf("After repush:\n");
+    printf("Region list length: {%i}\n", kls_rl_length(data_pt->regs));
+    kls_rl_showList(data_pt->regs);
+
     kls_free(kls);
     return 0;
 }

--- a/templates/kls_pit.h
+++ b/templates/kls_pit.h
@@ -29,7 +29,7 @@ static bool kls_cmp(const Koliseo* a, const Koliseo* b);
 
 static bool kls_cmp(const Koliseo* a, const Koliseo* b)
 {
-    printf("%s: %p == %p?\n", __func__, *a, *b);
+    printf("%s: %p == %p?\n", __func__, (void*)a, (void*)b);
     return (a == b);
 }
 

--- a/tests/error/bad_new_size.k.stderr
+++ b/tests/error/bad_new_size.k.stderr
@@ -1,2 +1,2 @@
-[ERROR]    at kls_new_alloc_ext():  invalid requested kls size (-1). Min accepted is: (224).
+[ERROR]    at kls_new_alloc_ext():  invalid requested kls size (-1). Min accepted is: (240).
 [ERROR] [kls_push_zero_ext()]: Passed Koliseo was NULL.

--- a/tests/error/zero_count_err.k.stderr
+++ b/tests/error/zero_count_err.k.stderr
@@ -1,1 +1,1 @@
-[KLS]  Doing a zero-count push. size [4] padding [0] available [16152].
+[KLS]  Doing a zero-count push. size [4] padding [0] available [16136].


### PR DESCRIPTION
### Added

- Add `on_repush_last`, `on_temp_repush_last` handlers to `KLS_Hooks`

### Changed

- Fix invalid format specifier in `kls_cmp()` for `kls_pit` template